### PR TITLE
Implemented static code analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,13 +4,35 @@ on:
     branches:
       - 'master'
       - 'release/**'
+      - 'dev'
     types: [opened, reopened, edited, synchronize]
     paths:
       - '*.js'
       - 'test/**'
 jobs:
+  # scan code using CodeQL
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - 'javascript'
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1
   coverage:
     runs-on: ubuntu-latest
+    needs: analyze
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/.github/workflows/buildChrome.yml
+++ b/.github/workflows/buildChrome.yml
@@ -4,13 +4,35 @@ on:
     branches:
       - 'master'
       - 'release/**'
+      - 'dev'
     types: [opened, reopened, edited, synchronize]
     paths:
       - '*.js'
       - 'test/**'
 jobs:
+  # scan code using CodeQL
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - 'javascript'
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1
   buildChrome:
     runs-on: ubuntu-latest
+    needs: analyze
     steps:
     - uses: actions/checkout@v1
     - name: Test Chrome

--- a/.github/workflows/buildFF.yml
+++ b/.github/workflows/buildFF.yml
@@ -4,13 +4,35 @@ on:
     branches:
       - 'master'
       - 'release/**'
+      - 'dev'
     types: [opened, reopened, edited, synchronize]
     paths:
       - '*.js'
       - 'test/**'
 jobs:
+  # scan code using CodeQL
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - 'javascript'
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1
   buildFF:
     runs-on: ubuntu-latest
+    needs: analyze
     steps:
     - uses: actions/checkout@v1
     - name: Test Firefox

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,29 @@ env:
   AWS_KEY_SECRET: ${{ secrets.AWS_KEY_SECRET }}
   BUCKET: ${{ secrets.S3_PUBLIC_BUCKET }}
 jobs:
+  # scan code using CodeQL
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - 'javascript'
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1
   publish:
     runs-on: ubuntu-latest
+    needs: analyze
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/docs/template.md
+++ b/docs/template.md
@@ -7,8 +7,8 @@
 **GitHub Actions workflows status**
 
 [![Build status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-textbox/build?label=build&logo=mocha)](https://github.com/kaskadi/kaskadi-textbox/actions?query=workflow%3Abuild)
-[![BuildFF status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-textbox/build-on-firefox?label=firefox&logo=Mozilla%20Firefox&logoColor=white)](https://github.com/kaskadi/kaskadi-textbox/actions?query=workflow%3Abuild-on-firefox)
-[![BuildChrome status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-textbox/build-on-chrome?label=chrome&logo=Google%20Chrome&logoColor=white)](https://github.com/kaskadi/kaskadi-textbox/actions?query=workflow%3Abuild-on-chrome)
+[![BuildFF status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-textbox/build-on-firefox?label=firefox&logo=firefox-browser)](https://github.com/kaskadi/kaskadi-textbox/actions?query=workflow%3Abuild-on-firefox)
+[![BuildChrome status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-textbox/build-on-chrome?label=chrome&logo=google-chrome&logoColor=white)](https://github.com/kaskadi/kaskadi-textbox/actions?query=workflow%3Abuild-on-chrome)
 [![Publish status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-textbox/publish?label=publish&logo=Amazon%20AWS)](https://github.com/kaskadi/kaskadi-textbox/actions?query=workflow%3Apublish)
 [![Docs generation status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-textbox/generate-docs?label=docs&logo=read-the-docs)](https://github.com/kaskadi/kaskadi-textbox/actions?query=workflow%3Agenerate-docs)
 
@@ -17,10 +17,6 @@
 [![](https://img.shields.io/codeclimate/maintainability/kaskadi/kaskadi-textbox?label=maintainability&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/kaskadi-textbox)
 [![](https://img.shields.io/codeclimate/tech-debt/kaskadi/kaskadi-textbox?label=technical%20debt&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/kaskadi-textbox)
 [![](https://img.shields.io/codeclimate/coverage/kaskadi/kaskadi-textbox?label=test%20coverage&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/kaskadi-textbox)
-
-**LGTM**
-
-[![](https://img.shields.io/lgtm/grade/javascript/github/kaskadi/kaskadi-textbox?label=code%20quality&logo=LGTM)](https://lgtm.com/projects/g/kaskadi/kaskadi-textbox/?mode=list&logo=LGTM)
 
 <!-- You can add badges inside of this section if you'd like -->
 

--- a/kaskadi-textbox.js
+++ b/kaskadi-textbox.js
@@ -179,3 +179,5 @@ function endLabelStyles () {
     }
   `
 }
+
+// force


### PR DESCRIPTION
**Changes description**
Added GitHub official static code analysis (via `CodeQL`, same as `LGTM`) inside of `build` and `publish` workflows.

**Updated features**
- _`build`/`publish` workflows:_ added static code analysis for vulnerability as a first step of the workflow. If this steps fails, the downstream steps will not run. Any vulnerabilities will be reported by the code analysis actions inside of the `Security` tab of the repository. Also fixed triggers.
- _documentation template:_ updated badges accordingly.